### PR TITLE
bug fix: support ec-384

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
 

--- a/gcp/e2e_test.go
+++ b/gcp/e2e_test.go
@@ -11,6 +11,7 @@ var keys = map[string]string{
 	"RSA-PSS-SHA256": "projects/used-for-testing-001/locations/europe-west1/keyRings/gojwt/cryptoKeys/rsa-pss-256/cryptoKeyVersions/1",
 	"RSA-PKCS1":      "projects/used-for-testing-001/locations/europe-west1/keyRings/gojwt/cryptoKeys/rsa-pkcs1-256/cryptoKeyVersions/1",
 	"EC-256":         "projects/used-for-testing-001/locations/europe-west1/keyRings/gojwt/cryptoKeys/ec-256/cryptoKeyVersions/1",
+	"EC-384":         "projects/used-for-testing-001/locations/europe-west1/keyRings/gojwt/cryptoKeys/ec-384/cryptoKeyVersions/1",
 }
 
 func TestE2ESigningAndVerifying(t *testing.T) {

--- a/gcp/kms.go
+++ b/gcp/kms.go
@@ -21,6 +21,8 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
+// ErrUnsupportedAlgorithm is an error used to indicate the GCP key's
+// algorithm is unsupported by gojwt.
 var ErrUnsupportedAlgorithm = errors.New("gojwt: unsupported algorithm")
 
 // KMS is an implementation of gojwt.Algorithm for Google Cloud
@@ -36,6 +38,9 @@ type KMS struct {
 	pubKeyData []byte
 }
 
+// New is used to instantiate a new version of KMS for the given key.
+// Note the the cryptoKeyVersion must be specified in the key name,
+// i.e. <key-name>/cryptoKeyVersions/1.
 func New(keyName string) (*KMS, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
 	defer cancel()

--- a/gcp/kms.go
+++ b/gcp/kms.go
@@ -132,7 +132,8 @@ func (kms *KMS) Verify(data, signature []byte) (bool, error) {
 		proto.CryptoKeyVersion_RSA_SIGN_PSS_4096_SHA512:
 		return kms.verifyRSAPSS(data, signature)
 	case proto.CryptoKeyVersion_EC_SIGN_P256_SHA256,
-		proto.CryptoKeyVersion_EC_SIGN_SECP256K1_SHA256:
+		proto.CryptoKeyVersion_EC_SIGN_SECP256K1_SHA256,
+		proto.CryptoKeyVersion_EC_SIGN_P384_SHA384:
 		return kms.verifyEC(data, signature)
 	default:
 		return false, ErrUnsupportedAlgorithm


### PR DESCRIPTION
I found a bug where JWTs signed with EC384 could not be verified. I've updated `*KMS.Verify(...)` method to handle EC384.